### PR TITLE
build: babel-plugin-transform-require-context

### DIFF
--- a/jest/babel.config.js
+++ b/jest/babel.config.js
@@ -10,7 +10,5 @@ module.exports = {
       { decoratorsBeforeExport: false },
     ],
     '@babel/plugin-transform-runtime',
-    // FIXME TRY WITHOUT THIS ??
-    'transform-require-context'
   ],
 };

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "babel-jest": "^28.1.3",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-require-context-hook": "^1.0.0",
-    "babel-plugin-transform-require-context": "^0.1.1",
     "eslint": "^7.32.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^26.6.0",


### PR DESCRIPTION
Removed import of babel-plugin-transform-require-context, and also removed it from the babel config file