### PR TITLE
build: decoratorsBeforeExport: true

### DIFF
--- a/jest/babel.config.js
+++ b/jest/babel.config.js
@@ -7,7 +7,7 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     [
       '@babel/plugin-proposal-decorators',
-      { decoratorsBeforeExport: false },
+      { decoratorsBeforeExport: true },
     ],
     '@babel/plugin-transform-runtime',
   ],


### PR DESCRIPTION
Changed decoratorsBeforeExport option in babel.config.js to `true`, which reflects how the rest of stripes sets up