### PR TITLE
build: stripes-kint-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-erm-testing
 
 ## 1.2.0 In progress
+  * Added stripes-kint-components to dev deps
 
 ## 1.1.0 2023-02-22
   * Initial e2e cypress tests

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@folio/stripes-testing": "^4.3.1",
     "@interactors/html": "^1.0.0-rc1.4",
     "@interactors/with-cypress": "^1.0.0-rc1.2",
+    "@k-int/stripes-kint-components": "^4.5.0",
     "@testing-library/dom": "^8.16.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react-hooks": "^8.0.0",


### PR DESCRIPTION
Added kint-components as a dev dependency as erm-testing does require kint-components now in order to provide KintIntlHarness