### PR TITLE
test: Mock getBoundingClientRect

### DIFF
--- a/jest/helpers/renderWithIntl.js
+++ b/jest/helpers/renderWithIntl.js
@@ -3,14 +3,42 @@ import { render } from '@testing-library/react';
 
 import Harness from './Harness';
 
-const renderWithIntl = (children, translations = [], renderer = render, extraOptions = {}) => renderer(
-  <Harness
-    intlKey={extraOptions.intlKey}
-    moduleName={extraOptions.moduleName}
-    translations={translations}
-  >
-    {children}
-  </Harness>
-);
+const renderWithIntl = (
+  children,
+  translations = [],
+  renderer = render,
+  extraOptions = {
+    mockWindowSize: true
+  }
+) => {
+  // Defaulting
+  const {
+    intlKey,
+    mockWindowSize = true,
+    moduleName
+  } = extraOptions;
+
+  if (mockWindowSize) {
+    // Ensure we mock getBoundingClientRect when we need it
+    window.HTMLElement.prototype.getBoundingClientRect = () => {
+      return {
+        width: 1920,
+        height: 1080,
+        top: 0,
+        left: 0
+      };
+    };
+  }
+
+  return renderer(
+    <Harness
+      intlKey={intlKey}
+      moduleName={moduleName}
+      translations={translations}
+    >
+      {children}
+    </Harness>
+  );
+};
 
 export default renderWithIntl;


### PR DESCRIPTION
Some components rely on getBoundingClientRect to ensure reactivity, and this is undefined within jsdom.

This work adds a defaulted getBoundingClientRect mock function, which can be turned off by using `extraOptions.mockWindowSize: false` in the props for renderWithIntl