### PR TITLE
test: Harness refactor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 // Helpers
 export {
   Harness,
+  BaseHarness,
+  KintIntlHarness,
+  CalloutHarness,
   renderWithIntl,
   TestForm,
   translationsProperties

--- a/jest/helpers/BaseHarness.js
+++ b/jest/helpers/BaseHarness.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { IntlProvider } from 'react-intl';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import prefixKeys from './prefixKeys';
+import mockOffsetSize from './mockOffsetSize';
+
+import CalloutHarness from './CalloutHarness';
+import ModuleHierarchyProvider from './ModuleHeirachyProvider';
+
+export default function BaseHarness({
+  children,
+  moduleName = '@folio/test-implementor',
+  translations: translationsConfig,
+  shouldMockOffsetSize = true,
+  width = 500,
+  height = 500,
+}) {
+  const queryClient = new QueryClient();
+  const allTranslations = {};
+
+  translationsConfig.forEach(tx => {
+    Object.assign(allTranslations, prefixKeys(tx.translations, tx.prefix));
+  });
+
+  if (shouldMockOffsetSize) { // MCL autosize mock
+    mockOffsetSize(width, height);
+  }
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider
+        key="en"
+        locale="en"
+        messages={allTranslations}
+        onError={() => {}}
+        timeZone="UTC"
+      >
+        <ModuleHierarchyProvider module={moduleName}>
+          <CalloutHarness>
+            {children}
+          </CalloutHarness>
+        </ModuleHierarchyProvider>
+        <div id="OverlayContainer" /> {/* This is the div which the all overlays will render inside */}
+      </IntlProvider>
+    </QueryClientProvider>
+  );
+}
+
+BaseHarness.propTypes = {
+  children: PropTypes.node,
+  moduleName: PropTypes.string,
+  translations: PropTypes.arrayOf(
+    PropTypes.shape({
+      prefix: PropTypes.string,
+      translations: PropTypes.object,
+    })
+  ),
+  shouldMockOffsetSize: PropTypes.bool,
+  width: PropTypes.number,
+  height: PropTypes.number,
+};
+
+BaseHarness.defaultProps = {
+  width: 500,
+  height: 500,
+  shouldMockOffsetSize: true,
+};

--- a/jest/helpers/Harness.js
+++ b/jest/helpers/Harness.js
@@ -1,61 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { IntlProvider } from 'react-intl';
-import { QueryClient, QueryClientProvider } from 'react-query';
 
-import prefixKeys from './prefixKeys';
-import mockOffsetSize from './mockOffsetSize';
-
-import CalloutHarness from './CalloutHarness';
-import ModuleHierarchyProvider from './ModuleHeirachyProvider';
-
-const KintIntlHarness = ({ children, intlKey, moduleName }) => {
-  const { useIntlKeyStore } = jest.requireActual('@k-int/stripes-kint-components');
-  const addKey = useIntlKeyStore(state => state.addKey);
-  addKey(intlKey, moduleName);
-
-  return children;
-};
+import KintIntlHarness from './KintIntlHarness';
+import BaseHarness from './BaseHarness';
 
 export default function Harness({
   children,
   intlKey = 'ui-test-implementor',
   moduleName = '@folio/test-implementor',
-  translations: translationsConfig,
+  translations,
   shouldMockOffsetSize = true,
   width = 500,
   height = 500,
 }) {
-  const queryClient = new QueryClient();
-  const allTranslations = {};
-
-  translationsConfig.forEach(tx => {
-    Object.assign(allTranslations, prefixKeys(tx.translations, tx.prefix));
-  });
-
-  if (shouldMockOffsetSize) { // MCL autosize mock
-    mockOffsetSize(width, height);
-  }
-
   return (
-    <QueryClientProvider client={queryClient}>
-      <IntlProvider
-        key="en"
-        locale="en"
-        messages={allTranslations}
-        onError={() => {}}
-        timeZone="UTC"
-      >
-        <ModuleHierarchyProvider module={moduleName}>
-          <CalloutHarness>
-            <KintIntlHarness intlKey={intlKey} moduleName={moduleName}>
-              {children}
-            </KintIntlHarness>
-          </CalloutHarness>
-        </ModuleHierarchyProvider>
-        <div id="OverlayContainer" /> {/* This is the div which the all overlays will render inside */}
-      </IntlProvider>
-    </QueryClientProvider>
+    <BaseHarness
+      intlKey={intlKey}
+      moduleName={moduleName}
+      translations={translations}
+      shouldMockOffsetSize={shouldMockOffsetSize}
+      width={width}
+      height={height}
+    >
+      <KintIntlHarness intlKey={intlKey} moduleName={moduleName}>
+        {children}
+      </KintIntlHarness>
+    </BaseHarness>
   );
 }
 

--- a/jest/helpers/KintIntlHarness.js
+++ b/jest/helpers/KintIntlHarness.js
@@ -1,0 +1,9 @@
+const KintIntlHarness = ({ children, intlKey, moduleName }) => {
+  const { useIntlKeyStore } = jest.requireActual('@k-int/stripes-kint-components');
+  const addKey = useIntlKeyStore(state => state.addKey);
+  addKey(intlKey, moduleName);
+
+  return children;
+};
+
+export default KintIntlHarness;

--- a/jest/helpers/index.js
+++ b/jest/helpers/index.js
@@ -1,4 +1,7 @@
 export { default as TestForm } from './TestForm';
 export { default as Harness } from './Harness';
+export { default as BaseHarness } from './BaseHarness';
+export { default as CalloutHarness } from './CalloutHarness';
+export { default as KintIntlHarness } from './KintIntlHarness';
 export { default as renderWithIntl } from './renderWithIntl';
 export { default as translationsProperties } from './translationsProperties';


### PR DESCRIPTION
Separate out Kint stuff from the harness, so that kint components can reuse the majority of the harness, but bypass the kint-components intl stuff that erm-testing adds