### PR TITLE
ERM-2973: Replace naive fetch hooks with parallelised ones (and deprecate)

### DIFF
--- a/jest/mocks/mockErmComponents.js
+++ b/jest/mocks/mockErmComponents.js
@@ -1,6 +1,7 @@
 const mockErmComponents = {
   useTags: jest.fn().mockReturnValue({ data: { tags: [] } }),
   useBatchedFetch: jest.fn().mockReturnValue({ results: [], total: 0 }),
+  useParallelBatchFetch: jest.fn().mockReturnValue({ items: [], total: 0 }),
   useInfiniteFetch: jest.fn().mockReturnValue({
     infiniteQueryObject: {
       error: '',


### PR DESCRIPTION
test: Added mock for new useParallelBatchFetch hook

ERM-2973