### PR TITLE
Updated to use mod-agreements-package schema v2.0

### DIFF
--- a/cypress/fixtures/simple_package_for_updates_1.json
+++ b/cypress/fixtures/simple_package_for_updates_1.json
@@ -2,7 +2,7 @@
   "header": {
     "dataSchema": {
       "name": "mod-agreements-package",
-      "version": 1
+      "version": "2.0"
     }
   },
   "records": [
@@ -66,6 +66,8 @@
       ],
       "contentItems": [
         {
+          "sourceIdentifier": "24134b52-05cd-47d3-ae4e-02d1e2d9c4fb",
+          "sourceIdentifierNamespace": "gokb",
           "depth": "fulltext",
           "platformTitleInstance": {
             "platform": "Academy of Management",


### PR DESCRIPTION
Following ERM-3018 mod-agreements now requires that JSON packages use the mod-agreements-package schema v2.0 which includes specifying a sourceIdentifier and sourceIdentifierNamespace for each package content item. This PR updates the simple_package_for_updates_1.json file to use the new schema