### PR TITLE
chore: Remove defaultProps

### DIFF
--- a/jest/helpers/BaseHarness.js
+++ b/jest/helpers/BaseHarness.js
@@ -62,8 +62,3 @@ BaseHarness.propTypes = {
   height: PropTypes.number,
 };
 
-BaseHarness.defaultProps = {
-  width: 500,
-  height: 500,
-  shouldMockOffsetSize: true,
-};

--- a/jest/helpers/Harness.js
+++ b/jest/helpers/Harness.js
@@ -43,9 +43,3 @@ Harness.propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
 };
-
-Harness.defaultProps = {
-  width: 500,
-  height: 500,
-  shouldMockOffsetSize: true,
-};


### PR DESCRIPTION
defaultProps is deprecated and will be removed in a future major version... we're not using it anyway so remove instances