### PR TITLE
ci: Add tag condition to workflow

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -13,5 +13,5 @@ jobs:
       jest-enabled: false
       sonar-enabled: false
     # Only handle push events from the main branch, to decrease noise
-    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit


### PR DESCRIPTION
Workflow previously did not run on tag push, so would never release