### PR TITLE
fix: Added default value for renderFooter prop

### DIFF
--- a/jest/componentMocks/mockTypedownGetter.js
+++ b/jest/componentMocks/mockTypedownGetter.js
@@ -9,7 +9,7 @@ const {
 const mockTypedownGetter = (optionArray = []) => ({
   id,
   input: { onChange, value },
-  renderFooter,
+  renderFooter = () => {},
   renderListItem
 }) => {
   return (


### PR DESCRIPTION
Added a default value for the renderFooter prop, as this is optional, some of our uses of either Typedown or QueryTypedown dont use it