### PR TITLE
test: Suppress certain errors

### DIFF
--- a/jest/jest.setup.js
+++ b/jest/jest.setup.js
@@ -1,1 +1,13 @@
 import './directMocks/window.mock';
+
+const suppressErrors = [
+  'findDOMNode', // This should be REMOVED once findDOMNode is properly stamped out from all dependencies
+  'Unknown event handler property `%s`' // These tend to come from stripes having "on..." props passed directly to html nodes. Might need to be reinstated
+];
+
+const originalError = console.error;
+console.error = jest.spyOn(console, 'error').mockImplementation((message, ...rest) => {
+  if (suppressErrors.every(m => !message.includes(m))) {
+    originalError.apply(console, [message, ...rest]);
+  }
+});


### PR DESCRIPTION
findDOMNode errors specifically cause us a lot of issues and come exclusively (thus far) from outside our module.

This is also true of props of type `on...` passed directly to html nodes. In general these are happening in Stripes not in our modules.

To that end, we wish to lower noise and allow ourselves to see actual errors and warnings in tests, and so we intercept console error itself and only display those errors not matching our list

This change lowers the number of errors in ui-agreements from 33 down to 4