### PR TITLE
fix test bug with TypeError

### DIFF
--- a/jest/mocks/mockReactRouterDom.js
+++ b/jest/mocks/mockReactRouterDom.js
@@ -1,6 +1,6 @@
 const mockReactRouterDom = {
   useLocation: jest.fn().mockReturnValue({}),
-  useHistory: jest.fn(() => ({ push: jest.fn(() => null) })),
+  useHistory: jest.fn(() => ({ push: jest.fn(() => null), replace: jest.fn(() => null) })),
   useParams: jest.fn().mockReturnValue({})
 };
 


### PR DESCRIPTION
* fix 'TypeError: history.replace is not a function' by adding the replace function to mockReactRouterDom