### PR TITLE
test: Add typescript files to test coverage collection

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,10 @@ const extraESModules = ['@folio', 'ky', '@k-int'].join('|');
 
 module.exports = {
   ...config,
+  collectCoverageFrom: [
+    ...config.collectCoverageFrom,
+    '**/(lib|src)/**/*.{ts,tsx}',
+  ],
   transformIgnorePatterns: [
     `/node_modules/(?!${extraESModules})`
   ],


### PR DESCRIPTION
Typescript files `.ts` and `.tsx` should be included in coverage report, but default config from @folio/jest-config-stripes does not currently include those