### PR TITLE
feat: Icon interactor

### DIFF
--- a/interactors/icon.js
+++ b/interactors/icon.js
@@ -1,0 +1,18 @@
+import { Bigtest } from '@folio/stripes-testing';
+
+export default Bigtest.createInteractor('icon')
+  .selector('[class^=icon-]')
+  .locator((el) => el.textContent)
+  .filters({
+    textContent: (el) => el.textContent,
+  });
+
+export const IconElement = Bigtest.createInteractor('icon-element')
+  .selector('[class^=stripes__icon]')
+  .filters({
+    // Get the icon name from the classlist
+    icon: (el) => {
+      // Take the classlist and find the icon-<iconName> class
+      return el.classList.toString().split(' ').find(cn => cn.startsWith('icon-')).replace('icon-', '');
+    }
+  });

--- a/interactors/index.js
+++ b/interactors/index.js
@@ -10,3 +10,4 @@ export { default as Select } from './select';
 export { default as AppList, AppListItem } from './app-list';
 export { default as NavList, NavListItem } from './nav-list';
 export { default as Badge } from './badge';
+export { default as Icon, IconElement } from './icon';

--- a/jest/jest.setup.js
+++ b/jest/jest.setup.js
@@ -1,13 +1,23 @@
 import './directMocks/window.mock';
 
 const suppressErrors = [
-  'findDOMNode', // This should be REMOVED once findDOMNode is properly stamped out from all dependencies
-  'Unknown event handler property `%s`' // These tend to come from stripes having "on..." props passed directly to html nodes. Might need to be reinstated
+  { errorString: 'findDOMNode' }, // This should be REMOVED once findDOMNode is properly stamped out from all dependencies
+  { errorString: 'Unknown event handler property `%s`' }, // These tend to come from stripes having "on..." props passed directly to html nodes. Might need to be reinstated
+  { errorString: 'Failed %s type: %s%s', context: 'Invalid prop `icon` supplied to `Icon`, expected one of type [function].' }, // Specifically this proptype fails in jest as it usually uses clever webpack stuff
 ];
 
 const originalError = console.error;
 console.error = jest.spyOn(console, 'error').mockImplementation((message, ...rest) => {
-  if (suppressErrors.every(m => message.includes instanceof Function && !message.includes(m))) {
+  const contextArray = [...rest];
+  if (suppressErrors.every(m => {
+    return (
+      message.includes instanceof Function &&
+      (
+        (!m.context && !message.includes(m.errorString)) || // If there is no context, and errorString matches, suppress
+        (message.includes(m.errorString) && !contextArray.includes(m.context)) // If the errorString matches AND context includes, suppress
+      )
+    );
+  })) {
     originalError.apply(console, [message, ...rest]);
   }
 });


### PR DESCRIPTION
Icons should now not instantly crash when in tests. This allows for testing of icons themselves.

Icon and IconElement interactors in place to help with this. However, that same fix ends up causing a console proptypes error, in jest harness we want to very specifically quash that error but no others.